### PR TITLE
feature/default load enabled tags only

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,9 @@ matched tags.
 @tom = User.find_by_name("Tom")
 @tom.skill_list # => ["hacking", "jogging", "diving"]
 
+# only enabled tags in the list
+@tom.enabled_skill_list # => ["only", "enabled", "skills"]
+
 @tom.find_related_skills # => [<User name="Bobby">, <User name="Frankie">]
 @bobby.find_related_skills # => [<User name="Tom">]
 @frankie.find_related_skills # => [<User name="Tom">]
@@ -292,6 +295,9 @@ to allow for dynamic tag contexts (this could be user generated tag contexts!)
 @user.tags_on(:customs) # => [<Tag name='same'>,...]
 @user.tag_counts_on(:customs)
 User.tagged_with("same", :on => :customs) # => [@user]
+
+# only enabled tags
+@user.enabled_tag_list_on(:customs) # => ["only", "enabled", "tags"]
 ```
 
 ### Tag Parsers

--- a/lib/acts_as_taggable_on/taggable.rb
+++ b/lib/acts_as_taggable_on/taggable.rb
@@ -81,7 +81,7 @@ module ActsAsTaggableOn
 
         class_eval do
           has_many :taggings, as: :taggable, dependent: :destroy, class_name: '::ActsAsTaggableOn::Tagging'
-          has_many :base_tags, -> { where enabled: true }, through: :taggings, source: :tag, class_name: '::ActsAsTaggableOn::Tag'
+          has_many :base_tags, through: :taggings, source: :tag, class_name: '::ActsAsTaggableOn::Tag'
 
           def self.taggable?
             true

--- a/lib/acts_as_taggable_on/taggable.rb
+++ b/lib/acts_as_taggable_on/taggable.rb
@@ -81,7 +81,7 @@ module ActsAsTaggableOn
 
         class_eval do
           has_many :taggings, as: :taggable, dependent: :destroy, class_name: '::ActsAsTaggableOn::Tagging'
-          has_many :base_tags, through: :taggings, source: :tag, class_name: '::ActsAsTaggableOn::Tag'
+          has_many :base_tags, -> { where enabled: true }, through: :taggings, source: :tag, class_name: '::ActsAsTaggableOn::Tag'
 
           def self.taggable?
             true

--- a/lib/acts_as_taggable_on/taggable/core.rb
+++ b/lib/acts_as_taggable_on/taggable/core.rb
@@ -34,7 +34,7 @@ module ActsAsTaggableOn::Taggable
                      after_add: :dirtify_tag_list,
                      after_remove: :dirtify_tag_list
 
-            has_many context_tags, -> { order(taggings_order) },
+            has_many context_tags, -> { order(taggings_order).where(enabled: true) },
                      class_name: 'ActsAsTaggableOn::Tag',
                      through: context_taggings,
                      source: :tag

--- a/lib/acts_as_taggable_on/taggable/core.rb
+++ b/lib/acts_as_taggable_on/taggable/core.rb
@@ -34,7 +34,7 @@ module ActsAsTaggableOn::Taggable
                      after_add: :dirtify_tag_list,
                      after_remove: :dirtify_tag_list
 
-            has_many context_tags, -> { order(taggings_order).where(enabled: true) },
+            has_many context_tags, -> { order(taggings_order) },
                      class_name: 'ActsAsTaggableOn::Tag',
                      through: context_taggings,
                      source: :tag
@@ -162,9 +162,26 @@ module ActsAsTaggableOn::Taggable
       end
     end
 
+    def enabled_tag_list_cache_on(context)
+      variable_name = "@enabled_#{context.to_s.singularize}_list"
+      if instance_variable_get(variable_name)
+        instance_variable_get(variable_name)
+      elsif cached_tag_list_on(context) && ensure_included_cache_methods! && self.class.caching_tag_list_on?(context)
+        instance_variable_set(variable_name, ActsAsTaggableOn.default_parser.new(cached_tag_list_on(context)).parse)
+      else
+        instance_variable_set(variable_name, ActsAsTaggableOn::TagList.new(tags_on(context).where(enabled: true).map(&:name)))
+      end
+    end
+
+
     def tag_list_on(context)
       add_custom_context(context)
       tag_list_cache_on(context)
+    end
+
+    def enabled_tag_list_on(context)
+      add_custom_context(context)
+      enabled_tag_list_cache_on(context)
     end
 
     def all_tags_list_on(context)

--- a/lib/acts_as_taggable_on/taggable/core.rb
+++ b/lib/acts_as_taggable_on/taggable/core.rb
@@ -47,6 +47,10 @@ module ActsAsTaggableOn::Taggable
               tag_list_on('#{tags_type}')
             end
 
+           def enabled_#{tag_type}_list
+              enabled_tag_list_on('#{tags_type}')
+            end
+
             def #{tag_type}_list=(new_tags)
               parsed_new_list = ActsAsTaggableOn.default_parser.new(new_tags).parse
 


### PR DESCRIPTION
Adding a new feature to the current gem.
The idea is since we have the concept of enabled/disabled tags, we would like to have some api methods for query the dynamic lists to have only enabled tags. 
This would avoid calling ActsAsTaggableOn::Tag.with_categories(context, true) to filter only the enabled tags.

```
@user.tag_list_on(:customs) 
vs
@user.enabled_tag_list_on(:customs)  # => ["enabled", "tags", "only"]
```


```
@user.skill_list
vs
@user.enabled_skill_list # => ["enabled", "tags", "only"]
```
This would avoid calling  ActsAsTaggableOn::Tag.with_categories(context, true) to filter only the enabled tags.