### PR TITLE
Add UUIDs to Tags

### DIFF
--- a/db/migrate/9_add_uuid_to_tags.rb
+++ b/db/migrate/9_add_uuid_to_tags.rb
@@ -1,0 +1,18 @@
+if ActiveRecord.gem_version >= Gem::Version.new('5.0')
+  class AddCategoryToTags < ActiveRecord::Migration[4.2]; end
+else
+  class AddCategoryToTags < ActiveRecord::Migration; end
+end
+AddCategoryToTags.class_eval do
+  def self.up
+    add_column ActsAsTaggableOn.tags_table, :uuid, :uuid
+
+    # Don't update existing tags directly in the migration since this can be a very long blocking
+    # task that can disrupt application deployments / provisioning. Use an ad-hoc call to
+    # ActsAsTaggableOn::Tag.populate_uuids when ready instead
+  end
+
+  def self.down
+    remove_column ActsAsTaggableOn.tags_table, :uuid
+  end
+end

--- a/db/migrate/9_add_uuid_to_tags.rb
+++ b/db/migrate/9_add_uuid_to_tags.rb
@@ -1,9 +1,9 @@
 if ActiveRecord.gem_version >= Gem::Version.new('5.0')
-  class AddUUIDToTags < ActiveRecord::Migration[4.2]; end
+  class AddUuidToTags < ActiveRecord::Migration[4.2]; end
 else
-  class AddUUIDToTags < ActiveRecord::Migration; end
+  class AddUuidToTags < ActiveRecord::Migration; end
 end
-AddUUIDToTags.class_eval do
+AddUuidToTags.class_eval do
   def self.up
     add_column ActsAsTaggableOn.tags_table, :uuid, :uuid
 

--- a/db/migrate/9_add_uuid_to_tags.rb
+++ b/db/migrate/9_add_uuid_to_tags.rb
@@ -1,9 +1,9 @@
 if ActiveRecord.gem_version >= Gem::Version.new('5.0')
-  class AddCategoryToTags < ActiveRecord::Migration[4.2]; end
+  class AddUUIDToTags < ActiveRecord::Migration[4.2]; end
 else
-  class AddCategoryToTags < ActiveRecord::Migration; end
+  class AddUUIDToTags < ActiveRecord::Migration; end
 end
-AddCategoryToTags.class_eval do
+AddUUIDToTags.class_eval do
   def self.up
     add_column ActsAsTaggableOn.tags_table, :uuid, :uuid
 

--- a/lib/acts_as_taggable_on/tag.rb
+++ b/lib/acts_as_taggable_on/tag.rb
@@ -119,14 +119,14 @@ module ActsAsTaggableOn
     end
 
     def self.populate_uuids
-      ActsAsTaggableOn::Tag.all.each do |tag|
-        if tag.uuid.present?
-          p "Tag '#{tag.name}': UUID already exists... Skipping!"
-        else
-          uuid = SecureRandom.uuid
-          tag.update(uuid: SecureRandom.uuid)
-          p "Tag '#{tag.name}': UUID is now #{uuid}!"
-        end
+      missing_uuid_query = ActsAsTaggableOn::Tag.where(uuid: nil)
+      missing_uuid_count = missing_uuid_query.count
+
+      missing_uuid_query.each_with_index do |tag, i|
+        uuid = SecureRandom.uuid
+        tag.update(uuid: uuid)
+
+        p "(#{i + 1} / #{missing_uuid_count}) Tag '#{tag.name}': UUID is now #{uuid}!"
       end
     end
 

--- a/lib/acts_as_taggable_on/tag.rb
+++ b/lib/acts_as_taggable_on/tag.rb
@@ -7,6 +7,10 @@ module ActsAsTaggableOn
 
     has_many :taggings, dependent: :destroy, class_name: '::ActsAsTaggableOn::Tagging'
 
+    ### CALLBACKS:
+
+    before_create :ensure_uuid
+
     ### VALIDATIONS:
 
     validates_presence_of :name
@@ -114,6 +118,18 @@ module ActsAsTaggableOn
       end
     end
 
+    def self.populate_uuids
+      ActsAsTaggableOn::Tag.all.each do |tag|
+        if tag.uuid.present?
+          p "Tag '#{tag.name}': UUID already exists... Skipping!"
+        else
+          uuid = SecureRandom.uuid
+          tag.update(uuid: SecureRandom.uuid)
+          p "Tag '#{tag.name}': UUID is now #{uuid}!"
+        end
+      end
+    end
+
     ### INSTANCE METHODS:
 
     def ==(object)
@@ -126,6 +142,12 @@ module ActsAsTaggableOn
 
     def count
       read_attribute(:count).to_i
+    end
+
+    private
+
+    def ensure_uuid
+      self.uuid = SecureRandom.uuid if self.uuid.blank?
     end
 
     class << self


### PR DESCRIPTION
We have a use case where we can benefit from having UUIDs on Tag records. 

* Providing the migration template to add the UUID column to the Tag table
* Ensure there is always a UUID at Tag creation
* Provide a class method to populate UUIDs for existing Tags (meant for console / script usage)

Note: Updating the current tags to have a UUID is not done inline in the migration because it's not uncommon to have tens of thousands of Tags in a production system; It would become a very long blocking operation if we were to do it there.